### PR TITLE
Feat/mark feature 2

### DIFF
--- a/src/app/(payload)/admin/importMap-v1.js
+++ b/src/app/(payload)/admin/importMap-v1.js
@@ -1,7 +1,7 @@
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { default as default_47fc9988fd3642c14df793050b7c9c6a } from '@/lexical/features/mark/feature.client'
+import { default as default_1866d528045e89ed7c25fd8164ec61b2 } from '../../../feature.client'
 import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -27,7 +27,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@/lexical/features/mark/feature.client#default": default_47fc9988fd3642c14df793050b7c9c6a,
+  "./feature.client#default": default_1866d528045e89ed7c25fd8164ec61b2,
   "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/src/lexical/features/mark/feature.client.tsx
+++ b/src/lexical/features/mark/feature.client.tsx
@@ -1,0 +1,40 @@
+// Inspired by https://github.com/payloadcms/payload/blob/59f536c2c97acc058e56b4293fc4f8b0b8f7eb4c/packages/richtext-lexical/src/features/format/underline/feature.client.tsx
+'use client'
+
+import { $isTableSelection } from '@lexical/table'
+import { $isRangeSelection, FORMAT_TEXT_COMMAND } from 'lexical'
+
+
+import { MarkIcon } from '../../ui/icons/Mark'
+import { createClientFeature, toolbarFormatGroupWithItems } from '@payloadcms/richtext-lexical/client'
+import { ToolbarGroup } from '@payloadcms/richtext-lexical'
+
+const toolbarGroups: ToolbarGroup[] = [
+  toolbarFormatGroupWithItems([
+    {
+      ChildComponent: MarkIcon,
+      isActive: ({ selection }) => {
+        if ($isRangeSelection(selection) || $isTableSelection(selection)) {
+          return selection.hasFormat('underline')
+        }
+        return false
+      },
+      key: 'mark',
+      onSelect: ({ editor }) => {
+        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')
+      },
+      order: 5,
+    },
+  ]),
+]
+
+// Inspired by https://github.com/Adoosko/multi-ecom/blob/95c70f7f50710c0f26109ad0f93173f2836dd501/src/features/fontColor/feature.client.ts
+export default createClientFeature({
+  enableFormats: ['underline'],
+  toolbarFixed: {
+    groups: toolbarGroups,
+  },
+  toolbarInline: {
+    groups: toolbarGroups,
+  },
+})

--- a/src/lexical/features/mark/feature.client.tsx
+++ b/src/lexical/features/mark/feature.client.tsx
@@ -15,13 +15,14 @@ const toolbarGroups: ToolbarGroup[] = [
       ChildComponent: MarkIcon,
       isActive: ({ selection }) => {
         if ($isRangeSelection(selection) || $isTableSelection(selection)) {
-          return selection.hasFormat('underline')
+          return selection.hasFormat('highlight')
         }
         return false
       },
-      key: 'mark',
+      key: 'highlight',
       onSelect: ({ editor }) => {
-        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')
+        console.log("dispatching highlight command")
+        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'highlight')
       },
       order: 5,
     },
@@ -30,7 +31,7 @@ const toolbarGroups: ToolbarGroup[] = [
 
 // Inspired by https://github.com/Adoosko/multi-ecom/blob/95c70f7f50710c0f26109ad0f93173f2836dd501/src/features/fontColor/feature.client.ts
 export default createClientFeature({
-  enableFormats: ['underline'],
+  enableFormats: ['highlight'],
   toolbarFixed: {
     groups: toolbarGroups,
   },

--- a/src/lexical/features/mark/feature.server.ts
+++ b/src/lexical/features/mark/feature.server.ts
@@ -1,0 +1,9 @@
+import { createServerFeature } from "@payloadcms/richtext-lexical";
+
+
+export const MarkFeature = createServerFeature({
+  feature: {
+    ClientFeature: '@/lexical/features/mark/feature.client',
+  },
+  key: 'mark',
+})

--- a/src/lexical/features/mark/feature.server.ts
+++ b/src/lexical/features/mark/feature.server.ts
@@ -5,5 +5,5 @@ export const MarkFeature = createServerFeature({
   feature: {
     ClientFeature: '@/lexical/features/mark/feature.client',
   },
-  key: 'mark',
+  key: 'highlight',
 })

--- a/src/lexical/ui/icons/Mark/index.tsx
+++ b/src/lexical/ui/icons/Mark/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 // Inspired by https://github.com/payloadcms/payload/blob/main/packages/richtext-lexical/src/lexical/ui/icons/Underline/index.tsx#L4
 export const MarkIcon: React.FC = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" style={{height: '20px', width: '20px'}}>
     {/* <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--> */}
     <path d="M315 315l158.4-215L444.1 70.6 229 229 315 315zm-187 5s0 0 0 0l0-71.7c0-15.3 7.2-29.6 19.5-38.6L420.6 8.4C428 2.9 437 0 446.2 0c11.4 0 22.4 4.5 30.5 12.6l54.8 54.8c8.1 8.1 12.6 19 12.6 30.5c0 9.2-2.9 18.2-8.4 25.6L334.4 396.5c-9 12.3-23.4 19.5-38.6 19.5L224 416l-25.4 25.4c-12.5 12.5-32.8 12.5-45.3 0l-50.7-50.7c-12.5-12.5-12.5-32.8 0-45.3L128 320zM7 466.3l63-63 70.6 70.6-31 31c-4.5 4.5-10.6 7-17 7L24 512c-13.3 0-24-10.7-24-24l0-4.7c0-6.4 2.5-12.5 7-17z" />
   </svg>

--- a/src/lexical/ui/icons/Mark/index.tsx
+++ b/src/lexical/ui/icons/Mark/index.tsx
@@ -1,0 +1,10 @@
+'use client'
+import React from 'react'
+
+// Inspired by https://github.com/payloadcms/payload/blob/main/packages/richtext-lexical/src/lexical/ui/icons/Underline/index.tsx#L4
+export const MarkIcon: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
+    {/* <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--> */}
+    <path d="M315 315l158.4-215L444.1 70.6 229 229 315 315zm-187 5s0 0 0 0l0-71.7c0-15.3 7.2-29.6 19.5-38.6L420.6 8.4C428 2.9 437 0 446.2 0c11.4 0 22.4 4.5 30.5 12.6l54.8 54.8c8.1 8.1 12.6 19 12.6 30.5c0 9.2-2.9 18.2-8.4 25.6L334.4 396.5c-9 12.3-23.4 19.5-38.6 19.5L224 416l-25.4 25.4c-12.5 12.5-32.8 12.5-45.3 0l-50.7-50.7c-12.5-12.5-12.5-32.8 0-45.3L128 320zM7 466.3l63-63 70.6 70.6-31 31c-4.5 4.5-10.6 7-17 7L24 512c-13.3 0-24-10.7-24-24l0-4.7c0-6.4 2.5-12.5 7-17z" />
+  </svg>
+)

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,6 +10,7 @@ import sharp from 'sharp'
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
 import { Posts } from './collections/Posts'  
+import { MarkFeature } from './lexical/features/mark/feature.server'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -22,7 +23,14 @@ export default buildConfig({
     },
   },
   collections: [Users, Media, Posts],
-  editor: lexicalEditor(),
+  editor: lexicalEditor({
+    features: ({defaultFeatures}) => {
+      return [
+        ...defaultFeatures,
+        MarkFeature()
+      ]
+    }
+  }),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),


### PR DESCRIPTION
## Summary by Sourcery

Add a new mark/highlight feature to the richtext-lexical integration by creating server and client modules, updating configuration to include it, and extending import maps for admin UI support.

New Features:
- Introduce a mark (highlight) formatting option in the richtext-lexical editor

Enhancements:
- Register the MarkFeature in the Payload editor configuration
- Extend the admin import maps to include the client-side MarkFeature module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a text highlighting (mark) feature to the rich text editor, allowing users to highlight selected text.
  - Introduced a new toolbar button with a highlight icon for easy access to the highlight functionality.

- **Chores**
  - Updated configuration to include the new highlight feature in the editor.
  - Expanded import maps to reference the new highlight feature modules and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->